### PR TITLE
readability rewrite

### DIFF
--- a/3_less.c
+++ b/3_less.c
@@ -15,6 +15,9 @@ exit 0
 #include "glad/glad.h"
 #include <GLFW/glfw3.h>
 
+#define PI 3.14159265358979323846
+#define HALF_PI 1.57079632679489661923
+
 #define min(a,b) ((a) < (b) ? (a) : (b))
 #define max(a,b) ((a) > (b) ? (a) : (b))
 #define clamp(val,minVal,maxVal) min(max(val, minVal), maxVal)
@@ -396,7 +399,7 @@ fn void loop(GLFWwindow *window) {
 	int _iy = 0;
 	int _iz = 0;
 	int _ij = 0;
-	
+
 	while(!glfwWindowShouldClose(window)) {
 		double time = glfwGetTime();
 		
@@ -422,8 +425,7 @@ fn void loop(GLFWwindow *window) {
 		P -= _my * 0.001f;
 		H -= _mx * 0.001f;
 		
-		if(P > +1.5707963f) P = +1.5707963f;
-		if(P < -1.5707963f) P = -1.5707963f;
+		P = clamp(P, -HALF_PI, HALF_PI);
 		if(H > +3.1415926f) H -= 6.2831852f;
 		if(H < -3.1415926f) H += 6.2831852f;
 		

--- a/3_less.c
+++ b/3_less.c
@@ -1,7 +1,7 @@
 
 #if 0
 
-python3 3_roomgen.py && clang -m64 $0 -std=c99 -Wall -Werror -Wno-unused -Wno-string-plus-int -Os -o ${0%.*}.exe -static -lglfw3 -lGdi32 &&
+python3 3_roomgen.py && clang -m64 -mwindows $0 -std=c99 -Wall -Werror -Wno-unused -Os -o ${0%.*}.exe -static -lglfw3 -lGdi32 &&
 
 exec ${0%.*}.exe "$@"
 exit 0
@@ -15,6 +15,9 @@ exit 0
 #include "glad/glad.h"
 #include <GLFW/glfw3.h>
 
+#define min(a,b) ((a) < (b) ? (a) : (b))
+#define max(a,b) ((a) > (b) ? (a) : (b))
+#define clamp(val,minVal,maxVal) min(max(val, minVal), maxVal)
 #define vr static
 #define fn static
 #define string(...) #__VA_ARGS__
@@ -167,6 +170,8 @@ vr int test_counter = 0;
 #undef fn
 #define fn static
 
+
+// opengl helper functions
 fn char *shader_error_log(unsigned shader) {
 	
 	int length;
@@ -202,6 +207,9 @@ fn unsigned create_shader(unsigned prog, GLenum type, char *src) {
 	return r;
 }
 
+// creates a new shader program from source
+// i normally write shaders with the string macro
+// but you could load them from seperate files aswell
 fn unsigned create_program(char *vert_src, char *frag_src) {
 	
 	int error = 0;
@@ -229,7 +237,12 @@ fn void loop(GLFWwindow *window) {
 	
 	glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
 	
-	// i use clip planes for this
+	#ifdef GLFW_RAW_MOUSE_MOTION
+	if(glfwRawMouseMotionSupported())
+		glfwSetInputMode(window, GLFW_RAW_MOUSE_MOTION, GLFW_TRUE);
+	#endif
+	
+	// i use clip planes
 	glEnable(GL_CLIP_PLANE0);
 	glEnable(GL_CLIP_PLANE1);
 	glEnable(GL_CLIP_PLANE2);
@@ -239,23 +252,37 @@ fn void loop(GLFWwindow *window) {
 	// because the stencil buffer is slow and annoying
 	
 	unsigned prog = create_program("#version 130\n" string(
+		// the vertex shader
 		
-		uniform vec4 u_xy;
-		uniform vec4 u_yz;
-		uniform vec4 u_zx;
-		uniform vec4 u_pos;
-		uniform vec3 u_scale;
+		// shader variable prefixes
+		// i_* === input *
+		// o_* === output *
+		// v_* === varying *
+		// u_* === uniform *
+		
+		// per room attributes
+		// these probably belong in a buffer
+		// then you could draw everything in a single call
+		uniform vec4 u_xy; // clip cone in the xy plane
+		uniform vec4 u_yz; // clip cone in the yz plane
+		uniform vec4 u_zx; // these match the ones in struct View
+		uniform vec4 u_pos; // the position of the room relative to the camera
+		uniform vec3 u_scale; // the scale of the room
+		
+		
+		// globals
 		uniform vec3 u_rgt;
-		uniform vec3 u_uwd;
+		uniform vec3 u_uwd; // these 3 are the camera matrix essentially
 		uniform vec3 u_fwd;
-		uniform float u_t;
+		uniform float u_t; // time
 		
 		centroid out vec3 v_vert;
 		out vec3 v_nor;
 		out vec3 v_pos;
 		
 		// this is a cube mesh
-		// im too lazy for vertex buffers :/
+		// normally you would put these in a vertex buffer
+		// but since we only draw cubes i just use an array
 		const vec3 vert[6 * 4] = vec3[]
 		( vec3(-1.,-1.,-1.),vec3(-1.,-1.,+1.),vec3(-1.,+1.,+1.),vec3(-1.,+1.,-1.)
 		, vec3(-1.,-1.,-1.),vec3(+1.,-1.,-1.),vec3(+1.,-1.,+1.),vec3(-1.,-1.,+1.)
@@ -266,6 +293,7 @@ fn void loop(GLFWwindow *window) {
 		, vec3(-1.,-1.,+1.),vec3(+1.,-1.,+1.),vec3(+1.,+1.,+1.),vec3(-1.,+1.,+1.)
 		);
 		
+		// we also need normals
 		const vec3 nor[6] = vec3[]
 		( vec3(+1., 0., 0.)
 		, vec3( 0.,+1., 0.)
@@ -277,10 +305,13 @@ fn void loop(GLFWwindow *window) {
 		);
 		
 		void main() {
+			// the roomN_render functions call glDrawArrays(GL_QUADS, 0, 24)
+			// then we can use GL_VertexID and vert[] to get a cube
 			v_vert = vert[gl_VertexID] * u_scale;
 			v_nor = nor[gl_VertexID / 4];
 			v_pos = v_vert - u_pos.xyz;
 			
+			// this does the clipping
 			gl_ClipDistance[0] = dot(v_pos.xy, u_xy.xy);
 			gl_ClipDistance[1] = dot(v_pos.xy, u_xy.zw);
 			gl_ClipDistance[2] = dot(v_pos.yz, u_yz.xy);
@@ -295,14 +326,11 @@ fn void loop(GLFWwindow *window) {
 			, dot(v_pos, u_fwd) * 2.0);
 		}
 	), "#version 130\n" string(
-		uniform vec4 u_xy;
-		uniform vec4 u_yz;
-		uniform vec4 u_zx;
+		// the fragment shader
+		
+		// same as before
 		uniform vec4 u_pos;
 		uniform vec3 u_scale;
-		uniform vec3 u_rgt;
-		uniform vec3 u_uwd;
-		uniform vec3 u_fwd;
 		uniform float u_asd;
 		uniform int u_frame;
 		uniform float u_t;
@@ -324,7 +352,7 @@ fn void loop(GLFWwindow *window) {
 			vec3 H = fwidth(hash23(floor(gl_FragCoord.xy * .75)));
 			vec3 w = u_scale - abs(v_vert);
 			vec3 a = vec3(101.1234, 132.534, 647.12);
-			float t = step(0., floor(dot(sin(v_vert + H*fwidth(v_vert)), u_scale))) * .1;
+			float t = step(0., floor(dot(sin(v_vert+H*fwidth(v_vert)), u_scale)))*.1;
 			vec3 c = fract(1. / cos(u_pos.w) * a + t + v_nor * .1);
 			c = c / (c + dot(1. / (1. + w*w), vec3(.2)) + H * .1);
 			o_color = vec4(pow(c, vec3(.5)), 1.0);
@@ -332,11 +360,16 @@ fn void loop(GLFWwindow *window) {
 	));
 	
 	glUseProgram(prog);
+	
+	// the room draw functions set these before calling glDrawArrays
+	// to set the room position and so on
 	u_xy_id = glGetUniformLocation(prog, "u_xy");
 	u_yz_id = glGetUniformLocation(prog, "u_yz");
 	u_zx_id = glGetUniformLocation(prog, "u_zx");
 	u_pos_id = glGetUniformLocation(prog, "u_pos");
 	u_scale_id = glGetUniformLocation(prog, "u_scale");
+	
+	// and these are only used in the main loop
 	int u_rgt_id = glGetUniformLocation(prog, "u_rgt");
 	int u_uwd_id = glGetUniformLocation(prog, "u_uwd");
 	int u_fwd_id = glGetUniformLocation(prog, "u_fwd");
@@ -355,11 +388,8 @@ fn void loop(GLFWwindow *window) {
 	glfwGetCursorPos(window, &mx, &my);
 	glClearColor(0, 0, 0, 0);
 	glEnable(GL_CULL_FACE);
-	glDisable(GL_DEPTH_TEST);
-	glfwSwapInterval(0);
-	
-	if(glfwRawMouseMotionSupported())
-		glfwSetInputMode(window, GLFW_RAW_MOUSE_MOTION, GLFW_TRUE);
+	glDisable(GL_DEPTH_TEST); // we dont need the depth buffer
+	glfwSwapInterval(0); // change it to 1 for vsync
 	
 	int jump = 0;
 	int _ix = 0;
@@ -403,8 +433,12 @@ fn void loop(GLFWwindow *window) {
 		float air_speed = 1;
 		float air_accel = 150;
 		
+		// speed = 1;
+		// accel = 170;
+		// friction = 0;
+		// air_accel = 170;
+		
 		{
-			
 			int ix = glfwGetKey(window, GLFW_KEY_D) - glfwGetKey(window, GLFW_KEY_A);
 			int iy = glfwGetKey(window, GLFW_KEY_E) - glfwGetKey(window, GLFW_KEY_Q);
 			int iz = glfwGetKey(window, GLFW_KEY_W) - glfwGetKey(window, GLFW_KEY_S);
@@ -557,6 +591,7 @@ int main(int argc, char *args[]) {
 	GLFWmonitor *monitor = glfwGetPrimaryMonitor();
 	const GLFWvidmode *mode = glfwGetVideoMode(monitor);
 	GLFWwindow *W = glfwCreateWindow(mode->width, mode->height, "", monitor, 0);
+	// glfwSetWindowMonitor(W, glfwGetPrimaryMonitor(), 0, 0, 1920, 1080, 362);
 	
 	if(W == 0) {
 		printf("Failed to open Window");

--- a/3_roomgen.py
+++ b/3_roomgen.py
@@ -1,416 +1,441 @@
-
-
-
-header = ''
+header = ""
 lsroom = []
 scale = 1
+from string import Template
 
 def linkrgt(id0, id1, a, b, c, d, z, y):
-	
-	a *= scale
-	b *= scale
-	c *= scale
-	d *= scale
-	z *= scale
-	y *= scale
-	
-	r = lsroom[id0]
-	s = ', '.join(map(lambda x: "%ff" % x, (a, b, c, d)))
-	
-	r[0] += '\tif(+v.px < room%d.w) {\n' % id0
-	r[0] += '\t\tView door = View_through_rgt(v, room%d.w, %s);\n' % (id0, s)
-	r[0] += '\t\tdoor.px -= room%d.w + room%d.w;\n' % (id0, id1)
-	r[0] += '\t\tdoor.py -= %ff;\n' % y
-	r[0] += '\t\tdoor.pz -= %ff;\n' % z
-	r[0] += '\t\tif(--depth) room%d_render(door);\n' % id1
-	r[0] += '\t\tdepth++;\n'
-	r[0] += '\t}\n'
-	
-	r[1] += '\tif(v.pz >= %ff+d)\n' % a
-	r[1] += '\tif(v.pz <= %ff-d)\n' % b
-	r[1] += '\tif(v.py >= %ff+d)\n' % c
-	r[1] += '\tif(v.py <= %ff-d)\n' % d
-	r[1] += '\tif(v.px + x > room%d.w - w) {\n' % id0
-	r[1] += '\t\tif(v.px + x > room%d.w) {\n' % id0
-	r[1] += '\t\t\t*r = &room%d;\n' % id1
-	r[1] += '\t\t\tv.px -= room%d.w + room%d.w;\n' % (id0, id1)
-	r[1] += '\t\t\tv.py -= %ff;\n' % y
-	r[1] += '\t\t\tv.pz -= %ff;\n' % z
-	r[1] += '\t\t\treturn room%d_update(v, r, w, d, dt);\n' % id1
-	r[1] += '\t\t}\n'
-	r[1] += '\t\tv.px += x;\n'
-	r[1] += '\t\tv.py += y;\n'
-	r[1] += '\t\tv.pz += z;\n'
-	
-	r[1] += '\t\tif(v.pz < %ff+d) v.pz = %ff+d, v.vz = 0;\n' % (a, a)
-	r[1] += '\t\tif(v.pz > %ff-d) v.pz = %ff-d, v.vz = 0;\n' % (b, b)
-	r[1] += '\t\tif(v.py < %ff+d) v.py = %ff+d, v.vy = 0;\n' % (c, c)
-	r[1] += '\t\tif(v.py > %ff-d) v.py = %ff-d, v.vy = 0;\n' % (d, d)
-	
-	r[1] += '\t\treturn v;\n'
-	r[1] += '\t}\n'
+
+    a = a*float(scale)
+    b = b*float(scale)
+    c = c*float(scale)
+    d = d*float(scale)
+    z = z*float(scale)
+    y = y*float(scale)
+
+    r = lsroom[id0]
+    s = ", ".join(map(lambda x: "%ff" % x, (a, b, c, d)))
+
+    # based on linkrgt
+    r[0] += Template("""
+        if(+v.px < room${id0}.w) {
+            View door = View_through_rgt(v, room${id0}.w, ${s});
+            door.px -= room${id0}.w + room${id1}.w;
+            door.py -= ${y}f;
+            door.pz -= ${z}f;
+            if (--depth) room${id1}_render(door);
+            depth++;
+        }
+    """).substitute(locals())
+
+    r[1] += Template("""
+        if(v.pz >= ${a}f+d &&
+            v.pz <= ${b}f-d &&
+            v.py >= ${c}f-d &&
+            v.py <= ${d}f-d &&
+            v.px + x > room${id0}.w - w) {
+                if (v.px + x > room${id0}.w) {
+                    *r = &room${id1};
+                    v.px -= room${id0}.w + room${id1}.w;
+                    v.py -= ${y}f;
+                    v.pz -= ${z}f;
+                    return room${id1}_update(v, r, w, d, dt);
+                }
+                v.px += x;
+                v.py += y;
+                v.pz += z;
+
+                //clamp defined in 3_less.c, like the glsl func
+                v.pz = clamp(v.pz, ${a}f+d, ${b}f-d);
+                v.py = clamp(v.py, ${c}f+d, ${d}f-d);
+
+                // when v.pz and v.py are equal to some boundary,
+                // v.vz and v.vy would not be set to 0 before.
+                // now it always sets to 0
+
+                //if (v.pz == ${a}f+d || v.pz == ${b}f-d)
+                v.vz = 0;
+                //if(v.py == ${c}f+d || v.py == ${d}f-d)
+                v.vy = 0;
+
+                return v;
+            }
+
+    """).substitute(locals())
 
 def linklft(id0, id1, a, b, c, d, z, y):
-	
-	a *= scale
-	b *= scale
-	c *= scale
-	d *= scale
-	z *= scale
-	y *= scale
-	
-	r = lsroom[id0]
-	s = ', '.join(map(lambda x: "%ff" % x, (a, b, c, d)))
-	
-	r[0] += '\tif(-v.px < room%d.w) {\n' % id0
-	r[0] += '\t\tView door = View_through_lft(v, -room%d.w, %s);\n' % (id0, s)
-	r[0] += '\t\tdoor.px += room%d.w + room%d.w;\n' % (id0, id1)
-	r[0] += '\t\tdoor.py -= %ff;\n' % y
-	r[0] += '\t\tdoor.pz -= %ff;\n' % z
-	r[0] += '\t\tif(--depth) room%d_render(door);\n' % id1
-	r[0] += '\t\tdepth++;\n'
-	r[0] += '\t}\n'
-	
-	r[1] += '\tif(v.pz >= %ff+d)\n' % a
-	r[1] += '\tif(v.pz <= %ff-d)\n' % b
-	r[1] += '\tif(v.py >= %ff+d)\n' % c
-	r[1] += '\tif(v.py <= %ff-d)\n' % d
-	r[1] += '\tif(v.px + x < -room%d.w + w) {\n' % id0
-	r[1] += '\t\tif(v.px + x < -room%d.w) {\n' % id0
-	r[1] += '\t\t\t*r = &room%d;\n' % id1
-	r[1] += '\t\t\tv.px += room%d.w + room%d.w;\n' % (id0, id1)
-	r[1] += '\t\t\tv.py -= %ff;\n' % y
-	r[1] += '\t\t\tv.pz -= %ff;\n' % z
-	r[1] += '\t\t\treturn room%d_update(v, r, w, d, dt);\n' % id1
-	r[1] += '\t\t}\n'
-	r[1] += '\t\tv.px += x;\n'
-	r[1] += '\t\tv.py += y;\n'
-	r[1] += '\t\tv.pz += z;\n'
-	
-	r[1] += '\t\tif(v.pz < %ff+d) v.pz = %ff+d, v.vz = 0;\n' % (a, a)
-	r[1] += '\t\tif(v.pz > %ff-d) v.pz = %ff-d, v.vz = 0;\n' % (b, b)
-	r[1] += '\t\tif(v.py < %ff+d) v.py = %ff+d, v.vy = 0;\n' % (c, c)
-	r[1] += '\t\tif(v.py > %ff-d) v.py = %ff-d, v.vy = 0;\n' % (d, d)
-	
-	r[1] += '\t\treturn v;\n'
-	r[1] += '\t}\n'
+
+    a = a*float(scale)
+    b = b*float(scale)
+    c = c*float(scale)
+    d = d*float(scale)
+    z = z*float(scale)
+    y = y*float(scale)
+
+    r = lsroom[id0]
+    s = ", ".join(map(lambda x: "%ff" % x, (a, b, c, d)))
+
+    r[0] += Template("""
+        if(-v.px < room${id0}.w) {
+            View door = View_through_lft(v, -room${id0}.w, ${s});
+            door.px += room${id0}.w + room${id1}.w;
+            door.py -= ${y}f;
+            door.pz -= ${z}f;
+            if (--depth) room${id1}_render(door);
+            depth++;
+        }
+    """).substitute(locals())
+
+    r[1] += Template("""
+        if(v.pz >= ${a}f+d &&
+           v.pz <= ${b}f-d &&
+           v.py >= ${c}f+d &&
+           v.py <= ${d}f-d &&
+           v.px + x < -room${id0}.w + w) {
+                if(v.px + x < -room${id0}.w) {
+                    *r = &room${id1};
+                    v.px += room${id0}.w + room${id1}.w;
+                    v.py -= ${y}f;
+                    v.pz -= ${z}f;
+                    return room${id1}_update(v,r,w,d,dt);
+                }
+
+                v.px += x;
+                v.py += y;
+                v.pz += z;
+            
+                v.pz = clamp(v.pz, ${a}f+d, ${b}f-d);
+                v.py = clamp(v.py, ${c}f+d, ${d}f-d);
+
+                v.vz = 0;
+                v.vy = 0;
+
+                return v;
+            }
+    """).substitute(locals())
+
 
 def linkuwd(id0, id1, a, b, c, d, x, z):
-	
-	a *= scale
-	b *= scale
-	c *= scale
-	d *= scale
-	x *= scale
-	z *= scale
-	
-	r = lsroom[id0]
-	s = ', '.join(map(lambda x: "%ff" % x, (a, b, c, d)))
-	
-	r[0] += '\tif(+v.py < room%d.h) {\n' % id0
-	r[0] += '\t\tView door = View_through_uwd(v, room%d.h, %s);\n' % (id0, s)
-	r[0] += '\t\tdoor.px -= %ff;\n' % x
-	r[0] += '\t\tdoor.py -= room%d.h + room%d.h;\n' % (id0, id1)
-	r[0] += '\t\tdoor.pz -= %ff;\n' % z
-	r[0] += '\t\tif(--depth) room%d_render(door);\n' % id1
-	r[0] += '\t\tdepth++;\n'
-	r[0] += '\t}\n'
-	
-	r[1] += '\tif(v.px >= %ff+d)\n' % a
-	r[1] += '\tif(v.px <= %ff-d)\n' % b
-	r[1] += '\tif(v.pz >= %ff+d)\n' % c
-	r[1] += '\tif(v.pz <= %ff-d)\n' % d
-	r[1] += '\tif(v.py + y > room%d.h - w) {\n' % id0
-	r[1] += '\t\tif(v.py + y > room%d.h) {\n' % id0
-	r[1] += '\t\t\t*r = &room%d;\n' % id1
-	r[1] += '\t\t\tv.px -= %ff;\n' % x
-	r[1] += '\t\t\tv.py -= room%d.h + room%d.h;\n' % (id0, id1)
-	r[1] += '\t\t\tv.pz -= %ff;\n' % z
-	r[1] += '\t\t\treturn room%d_update(v, r, w, d, dt);\n' % id1
-	r[1] += '\t\t}\n'
-	r[1] += '\t\tv.px += x;\n'
-	r[1] += '\t\tv.py += y;\n'
-	r[1] += '\t\tv.pz += z;\n'
-	
-	r[1] += '\t\tif(v.px < %ff+d) v.px = %ff+d, v.vx = 0;\n' % (a, a)
-	r[1] += '\t\tif(v.px > %ff-d) v.px = %ff-d, v.vx = 0;\n' % (b, b)
-	r[1] += '\t\tif(v.pz < %ff+d) v.pz = %ff+d, v.vz = 0;\n' % (c, c)
-	r[1] += '\t\tif(v.pz > %ff-d) v.pz = %ff-d, v.vz = 0;\n' % (d, d)
-	
-	r[1] += '\t\treturn v;\n'
-	r[1] += '\t}\n'
+
+    a = a*float(scale)
+    b = b*float(scale)
+    c = c*float(scale)
+    d = d*float(scale)
+    x = x*float(scale)
+    z = z*float(scale)
+
+    r = lsroom[id0]
+    s = ", ".join(map(lambda x: "%ff" % x, (a, b, c, d)))
+
+    r[0] += Template("""
+        if(+v.py < room${id0}.h) {
+            View door = View_through_uwd(v, room${id0}.h, ${s});
+            door.px -= ${x}f;
+            door.py -= room${id0}.h + room${id1}.h;
+            door.pz -= ${z}f;
+            if(--depth) room${id1}_render(door);
+            depth++;
+        }
+    """).substitute(locals())
+
+    r[1] += Template("""
+        if(v.px >= ${a}f+d &&
+           v.px <= ${b}f-d &&
+           v.pz >= ${c}f+d &&
+           v.pz <= ${d}f-d &&
+           v.py + y > room${id0}.h - w) {
+                if(v.py + y > room${id0}.h) {
+                    *r = &room${id1};
+                    v.px -= ${x}f;
+                    v.py -= room${id0}.h + room${id1}.h;
+                    v.pz -= ${z}f;
+                    return room${id1}_update(v,r,w,d,dt);
+                }
+                v.px += x;
+                v.py += y;
+                v.pz += z;
+
+                v.px = clamp(v.px, ${a}f+d, ${b}f-d);
+                v.pz = clamp(v.pz, ${c}f+d, ${d}f-d);
+
+                v.vx = 0;
+                v.vz = 0;
+
+                return v;
+           }
+    """).substitute(locals())
 
 def linkdwn(id0, id1, a, b, c, d, x, z):
-	
-	a *= scale
-	b *= scale
-	c *= scale
-	d *= scale
-	x *= scale
-	z *= scale
-	
-	r = lsroom[id0]
-	s = ', '.join(map(lambda x: "%ff" % x, (a, b, c, d)))
-	
-	r[0] += '\tif(-v.py < room%d.h) {\n' % id0
-	r[0] += '\t\tView door = View_through_dwn(v, -room%d.h, %s);\n' % (id0, s)
-	r[0] += '\t\tdoor.px -= %ff;\n' % x
-	r[0] += '\t\tdoor.py += room%d.h + room%d.h;\n' % (id0, id1)
-	r[0] += '\t\tdoor.pz -= %ff;\n' % z
-	r[0] += '\t\tif(--depth) room%d_render(door);\n' % id1
-	r[0] += '\t\tdepth++;\n'
-	r[0] += '\t}\n'
-	
-	r[1] += '\tif(v.px >= %ff+d)\n' % a
-	r[1] += '\tif(v.px <= %ff-d)\n' % b
-	r[1] += '\tif(v.pz >= %ff+d)\n' % c
-	r[1] += '\tif(v.pz <= %ff-d)\n' % d
-	r[1] += '\tif(v.py + y < -room%d.h + w) {\n' % id0
-	r[1] += '\t\tif(v.py + y < -room%d.h) {\n' % id0
-	r[1] += '\t\t\t*r = &room%d;\n' % id1
-	r[1] += '\t\t\tv.px -= %ff;\n' % x
-	r[1] += '\t\t\tv.py += room%d.h + room%d.h;\n' % (id0, id1)
-	r[1] += '\t\t\tv.pz -= %ff;\n' % z
-	r[1] += '\t\t\treturn room%d_update(v, r, w, d, dt);\n' % id1
-	r[1] += '\t\t}\n'
-	r[1] += '\t\tv.px += x;\n'
-	r[1] += '\t\tv.py += y;\n'
-	r[1] += '\t\tv.pz += z;\n'
-	
-	r[1] += '\t\tif(v.px < %ff+d) v.px = %ff+d, v.vx = 0;\n' % (a, a)
-	r[1] += '\t\tif(v.px > %ff-d) v.px = %ff-d, v.vx = 0;\n' % (b, b)
-	r[1] += '\t\tif(v.pz < %ff+d) v.pz = %ff+d, v.vz = 0;\n' % (c, c)
-	r[1] += '\t\tif(v.pz > %ff-d) v.pz = %ff-d, v.vz = 0;\n' % (d, d)
-	
-	r[1] += '\t\treturn v;\n'
-	r[1] += '\t}\n'
-	
-	r[2] += '\tif(v.px >= %ff)\n' % a
-	r[2] += '\tif(v.px <= %ff)\n' % b
-	r[2] += '\tif(v.pz >= %ff)\n' % c
-	r[2] += '\tif(v.pz <= %ff) {\n' % d
-	r[2] += '\t\tv.px -= %ff;\n' % x
-	r[2] += '\t\tv.py += room%d.h + room%d.h;\n' % (id0, id1)
-	r[2] += '\t\tv.pz -= %ff;\n' % z
-	r[2] += '\t\treturn room%d_cast_down(v, d);\n' % id1
-	r[2] += '\t}\n'
+
+    a = a*float(scale)
+    b = b*float(scale)
+    c = c*float(scale)
+    d = d*float(scale)
+    x = x*float(scale)
+    z = z*float(scale)
+
+    r = lsroom[id0]
+    s = ", ".join(map(lambda x: "%ff" % x, (a, b, c, d)))
+
+    r[0] += Template("""
+        if(-v.py < room${id0}.h) {
+            View door = View_through_dwn(v, -room${id0}.h, ${s});
+            door.px -= ${x}f;
+            door.py += room${id0}.h + room${id1}.h;
+            door.pz -= ${z}f;
+            if(--depth) room${id1}_render(door);
+            depth++;
+        }""").substitute(locals())
+
+    r[1] += Template("""
+        if(v.px >= ${a}f+d &&
+           v.px <= ${b}f-d &&
+           v.pz >= ${c}f+d &&
+           v.pz <= ${d}f-d &&
+           v.py + y < -room${id0}.h + w) {
+                if (v.py + y < -room${id0}.h) {
+                    *r = &room${id1};
+                    v.px -= ${x}f;
+                    v.py += room${id0}.h + room${id1}.h;
+                    v.pz -= ${z}f;
+                    return room${id1}_update(v,r,w,d,dt);
+                }
+
+            v.px += x;
+            v.py += y;
+            v.pz += z;
+
+            v.px = clamp(v.px, ${a}f+d, ${b}f-d);
+            v.pz = clamp(v.pz, ${c}f+d, ${d}f-d);
+
+            v.vx = 0;
+            v.vz = 0;
+
+            return v;
+        }""").substitute(locals())
+
+    r[2] += Template("""
+        if (v.px >= ${a}f &&
+            v.px <= ${b}f &&
+            v.pz >= ${c}f &&
+            v.pz <= ${d}f) {
+                v.px -= ${x}f;
+                v.py += room${id0}.h + room${id1}.h;
+                v.pz -= ${z}f;
+                return room${id1}_cast_down(v, d);
+        }
+    """).substitute(locals())
 
 def linkfwd(id0, id1, a, b, c, d, x, y):
-	
-	a *= scale
-	b *= scale
-	c *= scale
-	d *= scale
-	x *= scale
-	y *= scale
-	
-	r = lsroom[id0]
-	s = ', '.join(map(lambda x: "%ff" % x, (a, b, c, d)))
-	
-	r[0] += '\tif(+v.pz < room%d.d) {\n' % id0
-	r[0] += '\t\tView door = View_through_fwd(v, room%d.d, %s);\n' % (id0, s)
-	r[0] += '\t\tdoor.px -= %ff;\n' % x
-	r[0] += '\t\tdoor.py -= %ff;\n' % y
-	r[0] += '\t\tdoor.pz -= room%d.d + room%d.d;\n' % (id0, id1)
-	r[0] += '\t\tif(--depth) room%d_render(door);\n' % id1
-	r[0] += '\t\tdepth++;\n'
-	r[0] += '\t}\n'
-	
-	r[1] += '\tif(v.px >= %ff+d)\n' % a
-	r[1] += '\tif(v.px <= %ff-d)\n' % b
-	r[1] += '\tif(v.py >= %ff+d)\n' % c
-	r[1] += '\tif(v.py <= %ff-d)\n' % d
-	r[1] += '\tif(v.pz + z > room%d.d - w) {\n' % id0
-	r[1] += '\t\tif(v.pz + z > room%d.d) {\n' % id0
-	r[1] += '\t\t\t*r = &room%d;\n' % id1
-	r[1] += '\t\t\tv.px -= %ff;\n' % x
-	r[1] += '\t\t\tv.py -= %ff;\n' % y
-	r[1] += '\t\t\tv.pz -= room%d.d + room%d.d;\n' % (id0, id1)
-	r[1] += '\t\t\tv = room%d_update(v, r, w, d, dt);\n' % id1
-	r[1] += '\t\t\tv.vz -= room%d._d + room%d._d;\n' % (id0, id1) # velocity
-	r[1] += '\t\t\treturn v;\n'
-	r[1] += '\t\t}\n'
-	r[1] += '\t\tv.px += x;\n'
-	r[1] += '\t\tv.py += y;\n'
-	r[1] += '\t\tv.pz += z;\n'
-	
-	r[1] += '\t\tif(v.px < %ff+d) v.px = %ff+d, v.vx = 0;\n' % (a, a)
-	r[1] += '\t\tif(v.px > %ff-d) v.px = %ff-d, v.vx = 0;\n' % (b, b)
-	r[1] += '\t\tif(v.py < %ff+d) v.py = %ff+d, v.vy = 0;\n' % (c, c)
-	r[1] += '\t\tif(v.py > %ff-d) v.py = %ff-d, v.vy = 0;\n' % (d, d)
-	
-	r[1] += '\t\treturn v;\n'
-	r[1] += '\t}\n'
+
+    a = a*float(scale)
+    b = b*float(scale)
+    c = c*float(scale)
+    d = d*float(scale)
+    x = x*float(scale)
+    y = y*float(scale)
+
+    r = lsroom[id0]
+    s = ", ".join(map(lambda x: "%ff" % x, (a, b, c, d)))
+
+    r[0] += Template("""
+        if(+v.pz < room${id0}.d) {
+            View door = View_through_fwd(v, room${id0}.d, ${s});
+            door.px -= ${x}f;
+            door.py -= ${y}f;
+            door.pz -= room${id0}.d + room${id1}.d;
+            if(--depth) room${id1}_render(door);
+            depth++;
+        }
+    """).substitute(locals())
+
+    r[1] += Template("""
+        if(v.px >= ${a}f+d &&
+           v.px <= ${b}f-d &&
+           v.py >= ${c}f+d &&
+           v.py <= ${d}f-d &&
+           v.pz + z > room${id0}.d - w) {
+                if(v.pz + z > room${id0}.d) {
+                    *r = &room${id1};
+                    v.px -= ${x}f;
+                    v.py -= ${y}f;
+                    v.pz -= room${id0}.d + room${id1}.d;
+                    v = room${id1}_update(v,r,w,d,dt);
+                    v.vz -= room${id0}._d + room${id1}._d; //velocity
+                    return v;
+                }
+
+                v.px += x;
+                v.py += y;
+                v.pz += z;
+
+                v.px = clamp(v.px, ${a}f+d, ${b}f-d);
+                v.py = clamp(v.py, ${c}f+d, ${d}f-d);
+
+                v.vx = 0;
+                v.vy = 0;
+
+                return v;
+           }
+    """).substitute(locals())
 
 def linkbwd(id0, id1, a, b, c, d, x, y):
-	
-	a *= scale
-	b *= scale
-	c *= scale
-	d *= scale
-	x *= scale
-	y *= scale
-	
-	r = lsroom[id0]
-	s = ', '.join(map(lambda x: "%ff" % x, (a, b, c, d)))
-	
-	r[0] += '\tif(-v.pz < room%d.d) {\n' % id0
-	r[0] += '\t\tView door = View_through_bwd(v, -room%d.d, %s);\n' % (id0, s)
-	r[0] += '\t\tdoor.px -= %ff;\n' % x
-	r[0] += '\t\tdoor.py -= %ff;\n' % y
-	r[0] += '\t\tdoor.pz += room%d.d + room%d.d;\n' % (id0, id1)
-	r[0] += '\t\tif(--depth) room%d_render(door);\n' % id1
-	r[0] += '\t\tdepth++;\n'
-	r[0] += '\t}\n'
-	
-	r[1] += '\tif(v.px >= %ff+d)\n' % a
-	r[1] += '\tif(v.px <= %ff-d)\n' % b
-	r[1] += '\tif(v.py >= %ff+d)\n' % c
-	r[1] += '\tif(v.py <= %ff-d)\n' % d
-	r[1] += '\tif(v.pz + z < -room%d.d + w) {\n' % id0
-	r[1] += '\t\tif(v.pz + z < -room%d.d) {\n' % id0
-	r[1] += '\t\t\t*r = &room%d;\n' % id1
-	r[1] += '\t\t\tv.px -= %ff;\n' % x
-	r[1] += '\t\t\tv.py -= %ff;\n' % y
-	r[1] += '\t\t\tv.pz += room%d.d + room%d.d;\n' % (id0, id1)
-	r[1] += '\t\t\tv = room%d_update(v, r, w, d, dt);\n' % id1
-	r[1] += '\t\t\tv.vz += room%d._d + room%d._d;\n' % (id0, id1) # velocity
-	r[1] += '\t\t\treturn v;\n'
-	r[1] += '\t\t}\n'
-	r[1] += '\t\tv.px += x;\n'
-	r[1] += '\t\tv.py += y;\n'
-	r[1] += '\t\tv.pz += z;\n'
-	
-	r[1] += '\t\tif(v.px < %ff+d) v.px = %ff+d, v.vx = 0;\n' % (a, a)
-	r[1] += '\t\tif(v.px > %ff-d) v.px = %ff-d, v.vx = 0;\n' % (b, b)
-	r[1] += '\t\tif(v.py < %ff+d) v.py = %ff+d, v.vy = 0;\n' % (c, c)
-	r[1] += '\t\tif(v.py > %ff-d) v.py = %ff-d, v.vy = 0;\n' % (d, d)
-	
-	r[1] += '\t\treturn v;\n'
-	r[1] += '\t}\n'
 
-def rgt(id0,z0,y0, id1,z1,y1, d,h):
-	linkrgt(id0, id1, z0-d, z0+d, y0-h, y0+h, z0-z1, y0-y1)
-	linklft(id1, id0, z1-d, z1+d, y1-h, y1+h, z1-z0, y1-y0)
+    a = a*float(scale)
+    b = b*float(scale)
+    c = c*float(scale)
+    d = d*float(scale)
+    x = x*float(scale)
+    y = y*float(scale)
 
-def lft(id0,z0,y0, id1,z1,y1, d,h):
-	linklft(id0, id1, z0-d, z0+d, y0-h, y0+h, z0-z1, y0-y1)
-	linkrgt(id1, id0, z1-d, z1+d, y1-h, y1+h, z1-z0, y1-y0)
+    r = lsroom[id0]
+    s = ", ".join(map(lambda x: "%ff" % x, (a, b, c, d)))
 
-def uwd(id0,x0,z0, id1,x1,z1, w,h):
-	linkuwd(id0, id1, x0-w, x0+w, z0-h, z0+h, x0-x1, z0-z1)
-	linkdwn(id1, id0, x1-w, x1+w, z1-h, z1+h, x1-x0, z1-z0)
+    r[0] += Template("""
+        if (-v.pz < room${id0}.d) {
+            View door = View_through_bwd(v, -room${id0}.d, ${s});
+            door.px -= ${x}f;
+            door.py -= ${y}f;
+            door.pz += room${id0}.d + room${id1}.d;
+            if (--depth) room${id1}_render(door);
+            depth++;
+        }
+    """).substitute(locals())
 
-def dwn(id0,x0,z0, id1,x1,z1, w,h):
-	linkdwn(id0, id1, x0-w, x0+w, z0-h, z0+h, x0-x1, z0-z1)
-	linkuwd(id1, id0, x1-w, x1+w, z1-h, z1+h, x1-x0, z1-z0)
+    r[1] += Template("""
+        if(v.px >= ${a}f+d &&
+           v.px <= ${b}f-d &&
+           v.py >= ${c}f+d &&
+           v.py <= ${d}f-d &&
+           v.pz + z < -room${id0}.d + w) {
+               if (v.pz + z < -room${id0}.d){
+                   *r = &room${id1};
+                   v.px -= ${x}f;
+                   v.py -= ${y}f;
+                   v.pz += room${id0}.d + room${id1}.d;
+                   v = room${id1}_update(v,r,w,d,dt);
+                   v.vz += room${id0}._d + room${id1}._d; //velocity
+                   return v;
+               }
 
-def fwd(id0,x0,y0, id1,x1,y1, w,h):
-	linkfwd(id0, id1, x0-w, x0+w, y0-h, y0+h, x0-x1, y0-y1)
-	linkbwd(id1, id0, x1-w, x1+w, y1-h, y1+h, x1-x0, y1-y0)
+               v.px += x;
+               v.py += y;
+               v.pz += z;
 
-def bwd(id0,x0,y0, id1,x1,y1, w,h):
-	linkbwd(id0, id1, x0-w, x0+w, y0-h, y0+h, x0-x1, y0-y1)
-	linkfwd(id1, id0, x1-w, x1+w, y1-h, y1+h, x1-x0, y1-y0)
+               v.px = clamp(v.px, ${a}f+d, ${b}f-d);
+               v.py = clamp(v.py, ${c}f+d, ${d}f-d);
+               
+               v.vx = 0;
+               v.vy = 0;
+
+               return v;
+           }
+    """).substitute(locals())
+
+
+def rgt(id0, z0, y0, id1, z1, y1, d, h):
+    linkrgt(id0, id1, z0 - d, z0 + d, y0 - h, y0 + h, z0 - z1, y0 - y1)
+    linklft(id1, id0, z1 - d, z1 + d, y1 - h, y1 + h, z1 - z0, y1 - y0)
+
+
+def lft(id0, z0, y0, id1, z1, y1, d, h):
+    linklft(id0, id1, z0 - d, z0 + d, y0 - h, y0 + h, z0 - z1, y0 - y1)
+    linkrgt(id1, id0, z1 - d, z1 + d, y1 - h, y1 + h, z1 - z0, y1 - y0)
+
+
+def uwd(id0, x0, z0, id1, x1, z1, w, h):
+    linkuwd(id0, id1, x0 - w, x0 + w, z0 - h, z0 + h, x0 - x1, z0 - z1)
+    linkdwn(id1, id0, x1 - w, x1 + w, z1 - h, z1 + h, x1 - x0, z1 - z0)
+
+
+def dwn(id0, x0, z0, id1, x1, z1, w, h):
+    linkdwn(id0, id1, x0 - w, x0 + w, z0 - h, z0 + h, x0 - x1, z0 - z1)
+    linkuwd(id1, id0, x1 - w, x1 + w, z1 - h, z1 + h, x1 - x0, z1 - z0)
+
+
+def fwd(id0, x0, y0, id1, x1, y1, w, h):
+    linkfwd(id0, id1, x0 - w, x0 + w, y0 - h, y0 + h, x0 - x1, y0 - y1)
+    linkbwd(id1, id0, x1 - w, x1 + w, y1 - h, y1 + h, x1 - x0, y1 - y0)
+
+
+def bwd(id0, x0, y0, id1, x1, y1, w, h):
+    linkbwd(id0, id1, x0 - w, x0 + w, y0 - h, y0 + h, x0 - x1, y0 - y1)
+    linkfwd(id1, id0, x1 - w, x1 + w, y1 - h, y1 + h, x1 - x0, y1 - y0)
+
 
 def room(w, h, d):
-	
-	w *= scale
-	h *= scale
-	d *= scale
-	
-	global header, lsroom
-	index = len(lsroom)
-	
-	header+='fn void room%d_render(View v);\n' % index
-	header+='fn View room%d_update(View v, Room **r'\
-	', float w, float d, float dt);\n' % index
-	header+='fn float room%d_cast_down(View v, float d);\n' % index
-	header+='vr Room room%d =\n' %index
-	header+='{ %f,%f,%f\n' % (w, h, d)
-	header+=', 0, 0, 0\n'
-	header+=', room%d_render\n' % index
-	header+=', room%d_update\n' % index
-	header+=', room%d_cast_down\n' % index
-	header+='};\n'
-	header+='\n'
-	
-	lsroom += [['', '', '']]
-	return index
+
+    w *= scale
+    h *= scale
+    d *= scale
+
+    global header, lsroom
+    index = len(lsroom)
+
+    header += Template("""
+        fn void room${index}_render(View v);
+        fn View room${index}_update(View v, Room **r, float w, float d, float dt);
+        fn float room${index}_cast_down(View v, float d);
+        vr Room room${index} = {
+            ${w}, ${h}, ${d},
+            0,0,0,
+            room${index}_render,
+            room${index}_update,
+            room${index}_cast_down
+        };
+    """).substitute(locals())
+
+    lsroom += [["", "", ""]]
+    return index
+
 
 def out():
-	index = 0
-	print('// AUTOGEN //')
-	print(header)
-	for r, u, c in lsroom:
-		s = "room%d.w, room%d.h, room%d.d" % (index, index, index)
-		print('fn void room%d_render(View v) {' % index)
-		print('\tif(v.xy[0] * v.xy[3] - v.xy[1] * v.xy[2] < 0) return;')
-		print('\tif(v.yz[0] * v.yz[3] - v.yz[1] * v.yz[2] < 0) return;')
-		print('\tif(v.zx[0] * v.zx[3] - v.zx[1] * v.zx[2] < 0) return;')
-		# print('\tif(test_counter==select) {')
-		print('\tglUniform4f(u_xy_id, v.xy[0], v.xy[1], v.xy[2], v.xy[3]);')
-		print('\tglUniform4f(u_yz_id, v.yz[0], v.yz[1], v.yz[2], v.yz[3]);')
-		print('\tglUniform4f(u_zx_id, v.zx[0], v.zx[1], v.zx[2], v.zx[3]);')
-		#print('glUniform4f(u_xy_id,nor2(v.xy[0],v.xy[1]),nor2(v.xy[2],v.xy[3]));')
-		#print('glUniform4f(u_yz_id,nor2(v.yz[0],v.yz[1]),nor2(v.yz[2],v.yz[3]));')
-		#print('glUniform4f(u_zx_id,nor2(v.zx[0],v.zx[1]),nor2(v.zx[2],v.zx[3]));')
-		# print('\tif(proggle) {')
-		# print('\tglUniform4f(u_xy_id, 0, 0, 0, 0);')
-		# print('\tglUniform4f(u_yz_id, 0, 0, 0, 0);')
-		# print('\tglUniform4f(u_zx_id, 0, 0, 0, 0);')
-		# print('\t}')
-		print('\tglUniform4f(u_pos_id, v.px, v.py, v.pz, %d);' % index)
-		# print('\tglUniform4f(u_pos_id, v.px, v.py, v.pz, %d + 0.1356f * _floorf(gtime + frand() * 0.5f));' % index)
-		print('\tglUniform3f(u_scale_id, %s);' % s)
-		print('\tglDrawArrays(GL_QUADS, 0, 4 * 6);')
-		# print('\tglUniform3f(u_scale_id, -.1f, -.1f, -.1f);')
-		# print('\tglDrawArrays(GL_QUADS, 0, 4 * 6);')
-		
-		# print('\tglUniform4f(u_xy_id, 0, 0, 0, 0);')
-		# print('\tglUniform4f(u_yz_id, 0, 0, 0, 0);')
-		# print('\tglUniform4f(u_zx_id, 0, 0, 0, 0);')
-		# print('\tglDrawArrays(GL_LINES, 0, 4 * 6);')
-		# print('\t}')
-		
-		print('\ttest_counter++;')
-		print(r)
-		# print('\tif(player_room!=&room%d) return;' % index)
-		# print('\tglUniform4f(u_xy_id, v.xy[0], v.xy[1], v.xy[2], v.xy[3]);')
-		# print('\tglUniform4f(u_yz_id, v.yz[0], v.yz[1], v.yz[2], v.yz[3]);')
-		# print('\tglUniform4f(u_zx_id, v.zx[0], v.zx[1], v.zx[2], v.zx[3]);')
-		# print('\tglUniform4f(u_pos_id, v.px-player_x, v.py-player_y, v.pz-player_z, -10);')
-		# print('\tglUniform3f(u_scale_id, -.1, -.1, -.1);')
-		# print('\tglDrawArrays(GL_QUADS, 0, 4 * 6);')
-		print('}')
-		print('fn View room%d_update(View v, Room **r'
-		', float w, float d, float dt) {' % index)
-		print('float x = v.vx * dt, y = v.vy * dt, z = v.vz * dt;')
-		print('\tif(-room%d.w < v.px && v.px < room%d.w' % (index, index))
-		print('\t&& -room%d.h < v.py && v.py < room%d.h' % (index, index))
-		print('\t&& -room%d.d < v.pz && v.pz < room%d.d' % (index, index))
-		print('\t);')
-		# print('\t) {')
-		print(u)
-		# print('\t}')
-		print('\tv.px += x;')
-		print('\tv.py += y;')
-		print('\tv.pz += z;')
-		print('\tif(v.px > room%d.w-w) v.px=room%d.w-w, v.vx*=0;' % (index, index))
-		print('\tif(v.py > room%d.h-w) v.py=room%d.h-w, v.vy*=-1;' % (index, index))
-		print('\tif(v.pz > room%d.d-w) v.pz=room%d.d-w, v.vz*=0;' % (index, index))
-		print('\tif(v.px < w-room%d.w) v.px=w-room%d.w, v.vx*=0;' % (index, index))
-		print('\tif(v.py < w-room%d.h) v.py=w-room%d.h, v.vy*=0;' % (index, index))
-		print('\tif(v.pz < w-room%d.d) v.pz=w-room%d.d, v.vz*=0;' % (index, index))
-		print('\treturn v;')
-		print('}')
-		print('fn float room%d_cast_down(View v, float d) {' % index)
-		print('\tif(d < v.py + room%d.h) return d;' % index)
-		print(c)
-		print('\treturn v.py + room%d.h;' % index)
-		print('}')
-		index += 1
+    index = 0
+    print("// AUTOGEN //")
+    print(header)
+    for r, u, c in lsroom:
+        s = "room%d.w, room%d.h, room%d.d" % (index, index, index)
+        print(Template("""
+            fn void room${index}_render(View v) {
+                if(v.xy[0] * v.xy[3] - v.xy[1] * v.xy[2] < 0) return;
+                if(v.yz[0] * v.yz[3] - v.yz[1] * v.yz[2] < 0) return;
+                if(v.zx[0] * v.zx[3] - v.zx[1] * v.zx[2] < 0) return;
+                glUniform4f(u_xy_id, v.xy[0], v.xy[1], v.xy[2], v.xy[3]);
+                glUniform4f(u_yz_id, v.yz[0], v.yz[1], v.yz[2], v.yz[3]);
+                glUniform4f(u_zx_id, v.zx[0], v.zx[1], v.zx[2], v.zx[3]);
+                glUniform4f(u_pos_id, v.px, v.py, v.pz, ${index});
+                glUniform3f(u_scale_id, ${s});
+                glDrawArrays(GL_QUADS, 0, 4 * 6);
+                test_counter++;
+                ${r}
+            }
 
+            fn View room${index}_update(View v, Room **r, float w, float d, float dt) {
+                float x = v.vx * dt, y = v.vy * dt, z = v.vz * dt;
+                if(-room${index}.w < v.px && v.px < room${index}.w
+                && -room${index}.h < v.py && v.py < room${index}.h
+                && -room${index}.d < v.pz && v.pz < room${index}.d);
+                ${u}
+            
+                v.px += x;
+                v.py += y;
+                v.pz += z;
+                if(v.px > room${index}.w-w) v.px=room${index}.w-w, v.vx*=0;
+                if(v.py > room${index}.h-w) v.py=room${index}.h-w, v.vy*=-1;
+                if(v.pz > room${index}.d-w) v.pz=room${index}.d-w, v.vz*=0;
+                if(v.px < w-room${index}.w) v.px=w-room${index}.w, v.vx*=0;
+                if(v.py < w-room${index}.h) v.py=w-room${index}.h, v.vy*=0;
+                if(v.pz < w-room${index}.d) v.pz=w-room${index}.d, v.vz*=0;
+
+                return v;
+            }
+            fn float room${index}_cast_down(View v, float d) {
+                if(d < v.py + room${index}.h)
+                    return d;
+            
+                return v.py + room${index}.h;
+            }
+        """).substitute(locals()))
+        index += 1
 
 
 # a = room(1, 2, 2)
@@ -426,18 +451,18 @@ c = room(4, 6, 4)
 d = room(4, 2, 6)
 e = room(4, 2, 1)
 
-uwd(a,0,+4, b,0,0, 4, 2)
-uwd(a,0,-4, c,0,0, 4, 2)
+uwd(a, 0, +4, b, 0, 0, 4, 2)
+uwd(a, 0, -4, c, 0, 0, 4, 2)
 
-fwd(d,0,0, b,0,4, 4, 2)
-bwd(d,0,0, c,0,4, 4, 2)
+fwd(d, 0, 0, b, 0, 4, 4, 2)
+bwd(d, 0, 0, c, 0, 4, 4, 2)
 
 # rgt(a,7,0, b,1,4, 1, 2)
 # fwd(a,3,0, b,+1,0, 1, 2)
 # fwd(b,0,4, b,-1,0, 1, 2)
-fwd(b,0,4, e,0,0, 4, 2)
+fwd(b, 0, 4, e, 0, 0, 4, 2)
 
-fwd(e,+2.5,0, a,+2.5,0, 1.5,2)
+fwd(e, +2.5, 0, a, +2.5, 0, 1.5, 2)
 # fwd(e,-2.5,0, a,-2.5,0, 1.5,2)
 # fwd(e,-2,0, c,0,10, 1, 2)
 
@@ -450,52 +475,52 @@ clb = room(2, 4, 6)
 clu = room(2, 1, 2)
 cld = room(2, 1, 2)
 
-uwd(col,+4,0, clr, 0,0, 2, 6)
-uwd(col,-4,0, cll, 0,0, 2, 6)
-uwd(clr, 0,0, col,+4,0, 2, 6)
-uwd(cll, 0,0, col,-4,0, 2, 6)
+uwd(col, +4, 0, clr, 0, 0, 2, 6)
+uwd(col, -4, 0, cll, 0, 0, 2, 6)
+uwd(clr, 0, 0, col, +4, 0, 2, 6)
+uwd(cll, 0, 0, col, -4, 0, 2, 6)
 
-lft(clr,+4,0, clf,0,0, 4, 4)
-lft(clr,-4,0, clb,0,0, 4, 4)
-rgt(cll,+4,0, clf,0,0, 4, 4)
-rgt(cll,-4,0, clb,0,0, 4, 4)
+lft(clr, +4, 0, clf, 0, 0, 4, 4)
+lft(clr, -4, 0, clb, 0, 0, 4, 4)
+rgt(cll, +4, 0, clf, 0, 0, 4, 4)
+rgt(cll, -4, 0, clb, 0, 0, 4, 4)
 
-uwd(col,0,+4, clf,0,0, 2, 2)
-uwd(col,0,-4, clb,0,0, 2, 2)
-dwn(col,0,+4, clf,0,0, 2, 2)
-dwn(col,0,-4, clb,0,0, 2, 2)
+uwd(col, 0, +4, clf, 0, 0, 2, 2)
+uwd(col, 0, -4, clb, 0, 0, 2, 2)
+dwn(col, 0, +4, clf, 0, 0, 2, 2)
+dwn(col, 0, -4, clb, 0, 0, 2, 2)
 
 # fwd(clb,0, 0, clf,0,0, 2, 4)
-fwd(col,0, 0, clb,0,0, 2, 4)
-fwd(clf,0, 0, col,0,0, 2, 4)
+fwd(col, 0, 0, clb, 0, 0, 2, 4)
+fwd(clf, 0, 0, col, 0, 0, 2, 4)
 
-uwd(cld,0,0, col,0,0, 2,2)
-uwd(col,0,0, clu,0,0, 2,2)
+uwd(cld, 0, 0, col, 0, 0, 2, 2)
+uwd(col, 0, 0, clu, 0, 0, 2, 2)
 
-uwd(a,2,0, cld,0,0, 2,2)
-uwd(clu,0,0, d,2,0, 2,2)
-uwd(a,-2,0, d,-2,0, 2,2)
+uwd(a, 2, 0, cld, 0, 0, 2, 2)
+uwd(clu, 0, 0, d, 2, 0, 2, 2)
+uwd(a, -2, 0, d, -2, 0, 2, 2)
 
 hall1 = room(1, 2, 33)
 hall2 = room(1, 2, 33)
 front = room(12, 12, 6)
 back = room(12, 12, 6)
 
-fwd(hall2,0,0, a,0,0, 1,2)
-bwd(hall2,0,0, back,0,-10, 1, 2)
+fwd(hall2, 0, 0, a, 0, 0, 1, 2)
+bwd(hall2, 0, 0, back, 0, -10, 1, 2)
 
-fwd(e,+2.5,0, a,+2.5,0, 1.5,2)
-fwd(front,-2.5,0, a,-2.5,0, 1.5,2)
-fwd(a,-2.5,0, back,-2.5,0, 1.5,2)
+fwd(e, +2.5, 0, a, +2.5, 0, 1.5, 2)
+fwd(front, -2.5, 0, a, -2.5, 0, 1.5, 2)
+fwd(a, -2.5, 0, back, -2.5, 0, 1.5, 2)
 
 
-fwd(e,0,0, hall1,0,0, 1, 2)
-fwd(hall1,0,0, front,0,-10, 1, 2)
-fwd(back,+6.5,0, front,+6.5,0, 5.5, 12)
-fwd(back,-6.5,0, front,-6.5,0, 5.5, 12)
+fwd(e, 0, 0, hall1, 0, 0, 1, 2)
+fwd(hall1, 0, 0, front, 0, -10, 1, 2)
+fwd(back, +6.5, 0, front, +6.5, 0, 5.5, 12)
+fwd(back, -6.5, 0, front, -6.5, 0, 5.5, 12)
 # fwd(back, 0,2, back, 0,2, 1, 10)
 # fwd(front, 0,2, front, 0,2, 1, 10)
-fwd(back, 0,2, front, 0,2, 1, 10)
+fwd(back, 0, 2, front, 0, 2, 1, 10)
 
 a = room(6, 2, 2)
 b = room(6, 2, 2)
@@ -509,65 +534,65 @@ h = room(8, 6, 2)
 
 i = room(8, 4, 8)
 
-fwd(front,0,-10, a,0,0, 6, 2)
-bwd(back,0,-10, b,0,0, 6, 2)
+fwd(front, 0, -10, a, 0, 0, 6, 2)
+bwd(back, 0, -10, b, 0, 0, 6, 2)
 
-lft(a,+.5,-.5, b,+.5,-.5, 0.5,1.5)
-lft(b,+.5,-.5, a,+.5,-.5, 0.5,1.5)
-lft(a,-.5,-.5, a,-.5,-.5, 0.5,1.5)
-lft(b,-.5,-.5, b,-.5,-.5, 0.5,1.5)
+lft(a, +0.5, -0.5, b, +0.5, -0.5, 0.5, 1.5)
+lft(b, +0.5, -0.5, a, +0.5, -0.5, 0.5, 1.5)
+lft(a, -0.5, -0.5, a, -0.5, -0.5, 0.5, 1.5)
+lft(b, -0.5, -0.5, b, -0.5, -0.5, 0.5, 1.5)
 
 # lft(a,0,0, a,0,0, 0.5,1)
 # lft(b,0,0, b,0,0, 0.5,1)
 
-fwd(a,+2,0, b,+2, 0, 2,2)
-bwd(b,-2,0, c,-2,+2, 2,2)
-fwd(a,-2,0, c,-2,-2, 2,2)
-fwd(c,+2,0, c,+2, -2, 2,2)
+fwd(a, +2, 0, b, +2, 0, 2, 2)
+bwd(b, -2, 0, c, -2, +2, 2, 2)
+fwd(a, -2, 0, c, -2, -2, 2, 2)
+fwd(c, +2, 0, c, +2, -2, 2, 2)
 
 # uwd(c,0,0, d,0,0, 2,2)
 # uwd(i,0,0, c,0,0, 2,2)
 
 
-uwd(c,+2,0, d,+3,+1, 2,2)
-uwd(c,-2,0, d,-3,-1, 2,2)
+uwd(c, +2, 0, d, +3, +1, 2, 2)
+uwd(c, -2, 0, d, -3, -1, 2, 2)
 
-rgt(d,0,-4, c,0,-2, 4,2)
+rgt(d, 0, -4, c, 0, -2, 4, 2)
 
-rgt(i,0,-2, e,0,-2, 4,2)
-lft(i,0,-2, f,0,-2, 4,2)
-fwd(d,0,-4, g,0,-4, 4,2)
-bwd(d,0,-4, h,0,-4, 4,2)
+rgt(i, 0, -2, e, 0, -2, 4, 2)
+lft(i, 0, -2, f, 0, -2, 4, 2)
+fwd(d, 0, -4, g, 0, -4, 4, 2)
+bwd(d, 0, -4, h, 0, -4, 4, 2)
 
-fwd(e,0,0, g,+6,-2, 2,4)
-fwd(f,0,0, g,-6,-2, 2,4)
-bwd(e,0,0, h,+6,-2, 2,4)
-bwd(f,0,0, h,-6,-2, 2,4)
+fwd(e, 0, 0, g, +6, -2, 2, 4)
+fwd(f, 0, 0, g, -6, -2, 2, 4)
+bwd(e, 0, 0, h, +6, -2, 2, 4)
+bwd(f, 0, 0, h, -6, -2, 2, 4)
 
-uwd(d,0,0, i,0,0, 4,4)
-uwd(d,+4.5,0, i,+4.5,0, 0.5,2)
-uwd(d,-4.5,0, i,-4.5,0, 0.5,2)
-uwd(d,0,+4.5, i,0,+4.5, 2,0.5)
-uwd(d,0,-4.5, i,0,-4.5, 2,0.5)
+uwd(d, 0, 0, i, 0, 0, 4, 4)
+uwd(d, +4.5, 0, i, +4.5, 0, 0.5, 2)
+uwd(d, -4.5, 0, i, -4.5, 0, 0.5, 2)
+uwd(d, 0, +4.5, i, 0, +4.5, 2, 0.5)
+uwd(d, 0, -4.5, i, 0, -4.5, 2, 0.5)
 
 
 cla = room(2, 6, 1)
 clb = room(2, 6, 1)
 
-fwd(col,+5,0, cla,0,0, 2,6)
-fwd(col,-5,0, clb,0,0, 2,6)
-
+fwd(col, +5, 0, cla, 0, 0, 2, 6)
+fwd(col, -5, 0, clb, 0, 0, 2, 6)
 
 
 n0 = room(1000, 4, 300)
 
-fwd(n0,-.5,-3, 2,-.5,-.5, .5, .5)
+fwd(n0, -0.5, -3, 2, -0.5, -0.5, 0.5, 0.5)
 rgt(n0, 0, 0, n0, 0, 0, 3, 4)
 # fwd(n0, 0, -3, n0, 0, -3, 1, 1)
-fwd(n0,+.5,-3, n0,-.5,-3, .5, .5)
+fwd(n0, +0.5, -3, n0, -0.5, -3, 0.5, 0.5)
 
 out()
 import sys
-sys.stdout = open('3_roomgen_output.h', 'w')
+
+sys.stdout = open("3_roomgen_output.h", "w")
 out()
 


### PR DESCRIPTION
to make it easier to read

 the python source code, I've swapped all the string additions to `string.Template`s instead.
It's the difference between this ![this](https://user-images.githubusercontent.com/11942597/88062587-54077180-cb69-11ea-98e1-02af9188dace.png) and that ![that](https://user-images.githubusercontent.com/11942597/88062581-536edb00-cb69-11ea-8099-2d7c59da6ca4.png)

variables are easier to see in the source now. Also, added a `clamp` function to `3_less.c`, which emulates the behaviour of [the glsl function](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/clamp.xhtml).

also, I took the liberty to rewrite @en-GB's nested ifs into a cascade of `&&`s.